### PR TITLE
Use M5.IMU for both MPU6886 and SH200Q

### DIFF
--- a/M5StickC_Anime/M5StickC_Anime.ino
+++ b/M5StickC_Anime/M5StickC_Anime.ino
@@ -15,7 +15,7 @@ int xpos = 40;
 void setup() {
   // put your setup code here, to run once:
   M5.begin();
-  M5.Sh200Q.Init();//加速度を有効//Acceleromater enable
+  M5.IMU.Init();//加速度を有効//Acceleromater enable
   
   M5.Axp.ScreenBreath(9);//画面輝度を設定(7~15)//Brightness
   M5.Lcd.setRotation(3);//画面を横向きに//DisplayRotation
@@ -25,7 +25,7 @@ void setup() {
 
 void loop() {
   // put your main code here, to run repeatedly:
-  M5.Sh200Q.getAccelData(&accX,&accY,&accZ);
+  M5.IMU.getAccelData(&accX,&accY,&accZ);
   accY = accY-0.0;//補正(必要なら)//Calibration(if necessary)
   if(accY<-0.2||accY>0.2){
     int moveSpeed = -int(floor(accY*10/2));


### PR DESCRIPTION
M5.IMU is the library for both MPU6886 and SH200Q.
M5StickC has changed the IMU from SH200Q to MPU6886 at the summer in 2019.

楽しい作品の公開ありがとうございます。
Twitterで見て早速、私のM5StickCで試したのですが、
画像が１つ表示されるだけで転がらなかったので修正しました。
M5StickCは2019年の夏ごろから、IMUがSH200QからMPU6886に変更されているようです。
M5.IMUとすることでSH200QとMPU6886の両対応となったと思います。
